### PR TITLE
Upgrade OKHttp dependency

### DIFF
--- a/aliyun-ecs/pom.xml
+++ b/aliyun-ecs/pom.xml
@@ -77,7 +77,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
             <exclusions>

--- a/aliyun-ecs/pom.xml
+++ b/aliyun-ecs/pom.xml
@@ -80,13 +80,6 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- provided by the jclouds-bouncycastle driver -->
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>

--- a/aliyun-ecs/src/test/java/org/jclouds/aliyun/ecs/compute/features/InstanceApiMockTest.java
+++ b/aliyun-ecs/src/test/java/org/jclouds/aliyun/ecs/compute/features/InstanceApiMockTest.java
@@ -17,7 +17,7 @@
 package org.jclouds.aliyun.ecs.compute.features;
 
 import com.google.common.collect.Iterables;
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import org.jclouds.aliyun.ecs.compute.internal.BaseECSComputeServiceApiMockTest;
 import org.jclouds.aliyun.ecs.domain.AvailableZone;
 import org.jclouds.aliyun.ecs.domain.Instance;

--- a/aliyun-ecs/src/test/java/org/jclouds/aliyun/ecs/compute/internal/BaseECSComputeServiceApiMockTest.java
+++ b/aliyun-ecs/src/test/java/org/jclouds/aliyun/ecs/compute/internal/BaseECSComputeServiceApiMockTest.java
@@ -23,9 +23,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.google.inject.Module;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.jclouds.ContextBuilder;
 import org.jclouds.aliyun.ecs.ECSComputeServiceApi;
 import org.jclouds.aliyun.ecs.ECSComputeServiceProviderMetadata;
@@ -61,7 +61,7 @@ public class BaseECSComputeServiceApiMockTest {
    @BeforeMethod
    public void start() throws IOException {
       server = new MockWebServer();
-      server.play();
+      server.start();
       ctx = ContextBuilder.newBuilder("alibaba-ecs").credentials("user", "password").endpoint(url("")).modules(modules)
             .overrides(overrides()).build();
       json = ctx.utils().injector().getInstance(Json.class);
@@ -81,7 +81,7 @@ public class BaseECSComputeServiceApiMockTest {
    }
 
    protected String url(String path) {
-      return server.getUrl(path).toString();
+      return server.url(path).toString();
    }
 
    protected MockResponse jsonResponse(String resource) {

--- a/dimensiondata/pom.xml
+++ b/dimensiondata/pom.xml
@@ -83,7 +83,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
             <exclusions>

--- a/dimensiondata/pom.xml
+++ b/dimensiondata/pom.xml
@@ -86,13 +86,6 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- Already provided by jclouds-sshj -->
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>

--- a/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/features/CustomerImageApiMockTest.java
+++ b/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/features/CustomerImageApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.jclouds.dimensiondata.cloudcontrol.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import org.jclouds.dimensiondata.cloudcontrol.internal.BaseAccountAwareCloudControlMockTest;
 import org.testng.annotations.Test;
 

--- a/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/features/NetworkApiMockTest.java
+++ b/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/features/NetworkApiMockTest.java
@@ -17,8 +17,8 @@
 package org.jclouds.dimensiondata.cloudcontrol.features;
 
 import com.google.common.collect.Lists;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.jclouds.dimensiondata.cloudcontrol.domain.FirewallRule;
 import org.jclouds.dimensiondata.cloudcontrol.domain.FirewallRuleTarget;
 import org.jclouds.dimensiondata.cloudcontrol.domain.IpRange;

--- a/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/features/ServerApiMockTest.java
+++ b/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/features/ServerApiMockTest.java
@@ -17,7 +17,7 @@
 package org.jclouds.dimensiondata.cloudcontrol.features;
 
 import com.google.common.collect.Lists;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.jclouds.dimensiondata.cloudcontrol.domain.CPU;
 import org.jclouds.dimensiondata.cloudcontrol.domain.Disk;
 import org.jclouds.dimensiondata.cloudcontrol.domain.NIC;

--- a/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/features/TagApiMockTest.java
+++ b/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/features/TagApiMockTest.java
@@ -17,7 +17,7 @@
 package org.jclouds.dimensiondata.cloudcontrol.features;
 
 import com.google.common.collect.ImmutableList;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.jclouds.dimensiondata.cloudcontrol.domain.Tag;
 import org.jclouds.dimensiondata.cloudcontrol.domain.TagInfo;
 import org.jclouds.dimensiondata.cloudcontrol.domain.TagKey;

--- a/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/internal/BaseAccountAwareCloudControlMockTest.java
+++ b/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/internal/BaseAccountAwareCloudControlMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.jclouds.dimensiondata.cloudcontrol.internal;
 
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.testng.annotations.BeforeMethod;
 
 import javax.ws.rs.HttpMethod;

--- a/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/internal/BaseDimensionDataCloudControlMockTest.java
+++ b/dimensiondata/src/test/java/org/jclouds/dimensiondata/cloudcontrol/internal/BaseDimensionDataCloudControlMockTest.java
@@ -23,9 +23,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.google.gson.JsonParser;
 import com.google.inject.Module;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.jclouds.ContextBuilder;
 import org.jclouds.concurrent.config.ExecutorServiceModule;
 import org.jclouds.dimensiondata.cloudcontrol.DimensionDataCloudControlApi;
@@ -79,7 +79,7 @@ public class BaseDimensionDataCloudControlMockTest implements IHookable {
    @BeforeMethod
    public void start() throws IOException {
       server = new MockWebServer();
-      server.play();
+      server.start();
       ctx = ContextBuilder.newBuilder(DimensionDataCloudControlProviderMetadata.builder().build()).credentials("", "")
             .endpoint(url("")).modules(modules).overrides(new Properties()).build();
       json = ctx.utils().injector().getInstance(Json.class);
@@ -135,7 +135,7 @@ public class BaseDimensionDataCloudControlMockTest implements IHookable {
    }
 
    protected String url(String path) {
-      return server.getUrl(path).toString();
+      return server.url(path).toString();
    }
 
    protected MockResponse jsonResponse(String resource) {
@@ -236,9 +236,9 @@ public class BaseDimensionDataCloudControlMockTest implements IHookable {
       return uriBuilder;
    }
 
-   public byte[] payloadFromResource(String resource) {
+   public String payloadFromResource(String resource) {
       try {
-         return toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8);
+         return toStringAndClose(getClass().getResourceAsStream(resource));
       } catch (IOException e) {
          throw Throwables.propagate(e);
       }

--- a/oneandone/pom.xml
+++ b/oneandone/pom.xml
@@ -86,7 +86,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <exclusions>
                 <!-- Already provided by jclouds-sshj -->

--- a/oneandone/pom.xml
+++ b/oneandone/pom.xml
@@ -88,14 +88,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <exclusions>
-                <!-- Already provided by jclouds-sshj -->
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-            </exclusions>
-            <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/compute/function/ServerToNodeMetadataTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/compute/function/ServerToNodeMetadataTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.name.Names;
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/compute/function/SingleServerApplianceToImageTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/compute/function/SingleServerApplianceToImageTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.compute.function;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import org.apache.jclouds.oneandone.rest.domain.SingleServerAppliance;
 import org.apache.jclouds.oneandone.rest.internal.BaseOneAndOneApiMockTest;
 import org.jclouds.compute.domain.Image;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/BlockStorageApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/BlockStorageApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import org.apache.jclouds.oneandone.rest.domain.BlockStorage;
 import org.apache.jclouds.oneandone.rest.domain.options.GenericQueryOptions;
 import org.apache.jclouds.oneandone.rest.internal.BaseOneAndOneApiMockTest;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/DataCenterApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/DataCenterApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.DataCenter;
 import org.apache.jclouds.oneandone.rest.domain.options.GenericQueryOptions;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/FirewallPolicyApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/FirewallPolicyApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.FirewallPolicy;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/ImageApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/ImageApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.Image;
 import org.apache.jclouds.oneandone.rest.domain.Image.CreateImage;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/LoadBalancerApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/LoadBalancerApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.LoadBalancer;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/MonitoringCenterApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/MonitoringCenterApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/MonitoringPolicyApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/MonitoringPolicyApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.MonitoringPolicy;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/PrivateNetworkApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/PrivateNetworkApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.PrivateNetwork;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/PublicIpApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/PublicIpApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.PublicIp;
 import org.apache.jclouds.oneandone.rest.domain.Types;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/ServerApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/ServerApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.Dvd;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/ServerApplianceApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/ServerApplianceApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.ServerAppliance;
 import org.apache.jclouds.oneandone.rest.domain.SingleServerAppliance;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/SharedStorageApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/SharedStorageApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.jclouds.oneandone.rest.domain.SharedStorage;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/SshKeyApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/SshKeyApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import org.apache.jclouds.oneandone.rest.domain.SshKey;
 import org.apache.jclouds.oneandone.rest.domain.options.GenericQueryOptions;
 import org.apache.jclouds.oneandone.rest.internal.BaseOneAndOneApiMockTest;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/VpnApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/features/VpnApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.oneandone.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import java.util.zip.ZipInputStream;
 import org.apache.jclouds.oneandone.rest.domain.Vpn;

--- a/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/internal/BaseOneAndOneApiMockTest.java
+++ b/oneandone/src/test/java/org/apache/jclouds/oneandone/rest/internal/BaseOneAndOneApiMockTest.java
@@ -23,8 +23,8 @@ import com.google.common.io.Resources;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import com.google.gson.JsonParser;
 import com.google.inject.Module;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.Set;
@@ -53,7 +53,7 @@ public class BaseOneAndOneApiMockTest {
    @BeforeMethod
    public void start() throws IOException {
       server = new MockWebServer();
-      server.play();
+      server.start();
       ApiContext<OneAndOneApi> ctx = ContextBuilder.newBuilder("oneandone")
               .credentials("token", "token")
               .endpoint(url(""))
@@ -75,7 +75,7 @@ public class BaseOneAndOneApiMockTest {
    }
 
    protected String url(String path) {
-      return server.getUrl(path).toString();
+      return server.url(path).toString();
    }
 
    protected String stringFromResource(String resourceName) {
@@ -104,7 +104,7 @@ public class BaseOneAndOneApiMockTest {
       String expectedContentType = "application/json";
 
       assertEquals(request.getHeader("Content-Type"), expectedContentType);
-      assertEquals(parser.parse(new String(request.getBody(), Charsets.UTF_8)), parser.parse(json));
+      assertEquals(parser.parse(request.getBody().readUtf8()), parser.parse(json));
       return request;
    }
 }

--- a/profitbricks-rest/pom.xml
+++ b/profitbricks-rest/pom.xml
@@ -86,7 +86,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <exclusions>
                 <!-- Already provided by jclouds-sshj -->

--- a/profitbricks-rest/pom.xml
+++ b/profitbricks-rest/pom.xml
@@ -88,14 +88,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <exclusions>
-                <!-- Already provided by jclouds-sshj -->
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-            </exclusions>
-            <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/compute/config/StatusPredicateTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/compute/config/StatusPredicateTest.java
@@ -17,7 +17,7 @@
 package org.apache.jclouds.profitbricks.rest.compute.config;
 
 import com.google.common.base.Predicate;
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.concurrent.TimeUnit;
 import org.apache.jclouds.profitbricks.rest.compute.config.ProfitBricksComputeServiceContextModule.DataCenterProvisioningStatePredicate;
 import org.apache.jclouds.profitbricks.rest.compute.config.ProfitBricksComputeServiceContextModule.ServerStatusPredicate;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/compute/function/ProvisionableToImageTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/compute/function/ProvisionableToImageTest.java
@@ -18,7 +18,7 @@ package org.apache.jclouds.profitbricks.rest.compute.function;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.Set;
 import org.apache.jclouds.profitbricks.rest.internal.BaseProfitBricksApiMockTest;
 import org.jclouds.compute.domain.Image;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/compute/function/ServerInDataCenterToNodeMetadataTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/compute/function/ServerInDataCenterToNodeMetadataTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.name.Names;
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.Set;
 import org.apache.jclouds.profitbricks.rest.ProfitBricksApi;
 import org.apache.jclouds.profitbricks.rest.ProfitBricksApiMetadata;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/compute/function/VolumeToVolumeTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/compute/function/VolumeToVolumeTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.compute.function;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import org.apache.jclouds.profitbricks.rest.internal.BaseProfitBricksApiMockTest;
 import org.jclouds.compute.domain.Volume;
 import org.jclouds.compute.domain.VolumeBuilder;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/DataCenterApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/DataCenterApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 
 import java.net.URI;
 import java.util.List;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/FirewallApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/FirewallApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.profitbricks.rest.domain.FirewallRule;
 import org.apache.jclouds.profitbricks.rest.domain.options.DepthOptions;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/ImageApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/ImageApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.profitbricks.rest.domain.Image;
 import org.apache.jclouds.profitbricks.rest.domain.options.DepthOptions;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/IpBlockApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/IpBlockApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.profitbricks.rest.domain.IpBlock;
 import org.apache.jclouds.profitbricks.rest.domain.Location;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/LanApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/LanApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.profitbricks.rest.domain.Lan;
 import org.apache.jclouds.profitbricks.rest.domain.options.DepthOptions;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/NicApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/NicApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.profitbricks.rest.domain.Nic;
 import org.apache.jclouds.profitbricks.rest.domain.options.DepthOptions;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/ServerApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/ServerApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.profitbricks.rest.domain.Image;
 import org.apache.jclouds.profitbricks.rest.domain.Server;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/SnapshotApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/SnapshotApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.List;
 import org.apache.jclouds.profitbricks.rest.domain.Snapshot;
 import org.apache.jclouds.profitbricks.rest.domain.options.DepthOptions;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/VolumeApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/features/VolumeApiMockTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jclouds.profitbricks.rest.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockResponse;
 import java.util.HashSet;
 import java.util.List;
 import org.apache.jclouds.profitbricks.rest.domain.LicenceType;

--- a/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/internal/BaseProfitBricksApiMockTest.java
+++ b/profitbricks-rest/src/test/java/org/apache/jclouds/profitbricks/rest/internal/BaseProfitBricksApiMockTest.java
@@ -38,9 +38,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import com.google.gson.JsonParser;
 import com.google.inject.Module;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 public class BaseProfitBricksApiMockTest {
 
@@ -58,7 +58,7 @@ public class BaseProfitBricksApiMockTest {
    @BeforeMethod
    public void start() throws IOException {
       server = new MockWebServer();
-      server.play();
+      server.start();
       ApiContext<ProfitBricksApi> ctx = ContextBuilder.newBuilder("profitbricks-rest")
 	      .credentials("username", "password")
 	      .endpoint(url(""))
@@ -79,7 +79,7 @@ public class BaseProfitBricksApiMockTest {
    }
 
    protected String url(String path) {
-      return server.getUrl(path).toString();
+      return server.url(path).toString();
    }
    
    protected MockResponse response204() {
@@ -119,7 +119,7 @@ public class BaseProfitBricksApiMockTest {
          expectedContentType = "application/json";
       
       assertEquals(request.getHeader("Content-Type"), expectedContentType);
-      assertEquals(parser.parse(new String(request.getBody(), Charsets.UTF_8)), parser.parse(json));
+      assertEquals(parser.parse(request.getBody().readUtf8()), parser.parse(json));
       return request;
    }
 }


### PR DESCRIPTION
The JClouds project module upgrades the okhttp server library and related dependencies such as mockwebserver from 2.2.0 to 3.14.9. The vendor switched the groupId declaration from com.squareup.okhttp to com.squareup.okhttp3.

Adjust imports and api calls for newer okhttp vers